### PR TITLE
added harper to the dependency graph

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm ci
 
       - name: Install Harper CLI
-        run: npm install -g harperdb
+        run: npm install -g harper
 
       - name: Setup Harper
         env:
@@ -38,27 +38,27 @@ jobs:
           LOGGING_STDSTREAMS: true
           THREADS_COUNT: 1
           THREADS_DEBUG: false
-        run: harperdb install
+        run: harper install
 
       # - name: Deploy data
       #   run: |
-      #     harperdb start
+      #     harper start
       #     sleep 10
-      #     harperdb deploy project=basic-data package=HarperDB/basic-data-example replicated=true
+      #     harper deploy project=basic-data package=HarperFast/basic-data-example replicated=true
       #     sleep 10
-      #     harperdb stop
+      #     harper stop
 
       - name: Build project
         run: npm run build
 
       - name: Add prebuilt flag to config
-        run: yq e '.["@harperdb/nextjs"].prebuilt = true' -i config.yaml
+        run: yq e '.["@harperfast/nextjs"].prebuilt = true' -i config.yaml
 
-      - name: Upload HarperDB logs
+      - name: Upload Harper logs
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: harperdb-logs
+          name: harper-logs
           path: /tmp/hdb/log/hdb.log
           retention-days: 7
 
@@ -68,7 +68,7 @@ jobs:
           HDB_USERNAME: ${{ secrets.HDB_USERNAME }}
           HDB_PASSWORD: ${{ secrets.HDB_PASSWORD }}
         run: |
-          harperdb deploy \
+          harper deploy \
             target="$HDB_TARGET" \
             username="$HDB_USERNAME" \
             password="$HDB_PASSWORD" \

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,74 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      node-version:
+        description: 'Node.js version'
+        required: true
+        type: choice
+        default: 'all'
+        options:
+          - 'all'
+          - '22'
+          - '24'
+          - '26'
+
+jobs:
+  generate-node-version-matrix:
+    name: Generate Node Version Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      node-versions: ${{ steps.set-node-versions.outputs.node-versions }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set Node versions
+        id: set-node-versions
+        run: |
+          if [ "${{ github.event.inputs.node-version }}" == "all" ] || [ -z "${{ github.event.inputs.node-version }}" ]; then
+            echo "node-versions=[22, 24, 26]" >> $GITHUB_OUTPUT
+          else
+            echo "node-versions=[${{ github.event.inputs.node-version }}]" >> $GITHUB_OUTPUT
+          fi
+
+  integration-tests:
+    name: Integration Tests (Node ${{ matrix.node-version }})
+    needs: [generate-node-version-matrix]
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ${{ fromJSON(needs.generate-node-version-matrix.outputs.node-versions) }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run integration tests
+        run: npm run test:integration
+        env:
+          HARPER_INTEGRATION_TEST_LOG_DIR: /tmp/harper-test-logs
+          FORCE_COLOR: '1'
+
+      - name: Upload Harper logs on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: harper-logs-node-${{ matrix.node-version }}
+          path: /tmp/harper-test-logs/
+          retention-days: 7

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -30,11 +30,13 @@ jobs:
 
       - name: Set Node versions
         id: set-node-versions
+        env:
+          NODE_VER: ${{ github.event.inputs.node-version }}
         run: |
-          if [ "${{ github.event.inputs.node-version }}" == "all" ] || [ -z "${{ github.event.inputs.node-version }}" ]; then
+          if [ "$NODE_VER" == "all" ] || [ -z "$NODE_VER" ]; then
             echo "node-versions=[22, 24, 26]" >> $GITHUB_OUTPUT
           else
-            echo "node-versions=[${{ github.event.inputs.node-version }}]" >> $GITHUB_OUTPUT
+            echo "node-versions=[$NODE_VER]" >> $GITHUB_OUTPUT
           fi
 
   integration-tests:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The easiest way to demonstrate this application remotely is to use the `prebuilt
 3. Then deploy the prebuilt application using the Harper CLI:
 
 ```bash
-harperdb deploy \
+harper deploy \
 	target="<operations api url>" \
 	username="<username>" \
 	password='<password>' \

--- a/integrationTests/app.test.ts
+++ b/integrationTests/app.test.ts
@@ -1,0 +1,117 @@
+// Integration tests for the Harper Next.js example.
+//
+// Architecture note: this component is served by the `@harperfast/nextjs` plugin,
+// which owns the public HTTP port and routes every request to the Next.js app.
+// The `Dog` table (schema.graphql: `type Dog @table @export`) is therefore NOT
+// reachable as a REST resource over HTTP here — the Next.js server actions
+// (app/actions.js) read and write it through Harper's in-process Resource API
+// (`tables.Dog`). To exercise the same data layer from a test, we drive the
+// Dog table through the Operations API, and separately assert that the Next.js
+// pages render.
+//
+// These tests boot the full component as a fixture under v5 and verify:
+//   1. the component boots and the `Dog` table is defined,
+//   2. create / read-by-id / delete on the `Dog` table (Operations API),
+//   3. the Next.js HTML routes ("/" and "/dogs") render.
+
+import { suite, test, before, after } from 'node:test';
+import { strictEqual, ok, deepStrictEqual } from 'node:assert/strict';
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = resolve(__dirname, '..');
+
+// The `harper` package's `exports` map only exposes ".", so the harness's
+// auto-resolution of 'harper/dist/bin/harper.js' fails with ERR_PACKAGE_PATH_NOT_EXPORTED.
+// Resolve the CLI from the (exported) main entry and pass it explicitly.
+const require = createRequire(import.meta.url);
+const harperBinPath = resolve(dirname(require.resolve('harper')), 'bin/harper.js');
+
+function authHeader(ctx: ContextWithHarper): string {
+	const creds = Buffer.from(`${ctx.harper.admin.username}:${ctx.harper.admin.password}`).toString('base64');
+	return `Basic ${creds}`;
+}
+
+// Drive the Harper data layer (the same layer the Next.js server actions use)
+// through the Operations API, since the HTTP port is owned by the Next.js plugin.
+async function op<T = unknown>(ctx: ContextWithHarper, operation: Record<string, unknown>): Promise<T> {
+	const res = await fetch(ctx.harper.operationsAPIURL, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json', 'Authorization': authHeader(ctx) },
+		body: JSON.stringify(operation),
+	});
+	ok(res.ok, `operation ${String(operation.operation)} failed with HTTP ${res.status}`);
+	return (await res.json()) as T;
+}
+
+function pageFetch(ctx: ContextWithHarper, path: string) {
+	return fetch(`${ctx.harper.httpURL}${path}`, { headers: { Authorization: authHeader(ctx) } });
+}
+
+void suite('Harper Next.js example', (ctx: ContextWithHarper) => {
+	before(async () => {
+		await setupHarperWithFixture(ctx, FIXTURE_PATH, { harperBinPath });
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+	});
+
+	void test('component boots and the Dog table is defined', async () => {
+		const desc = await op<{ data: { Dog?: { name: string; primary_key: string } } }>(ctx, {
+			operation: 'describe_all',
+		});
+		ok(desc.data?.Dog, 'expected a Dog table in the "data" database');
+		strictEqual(desc.data.Dog.name, 'Dog');
+		strictEqual(desc.data.Dog.primary_key, 'id');
+	});
+
+	void test('insert, read-by-id, and delete a Dog (Resource API via Operations API)', async () => {
+		await op(ctx, {
+			operation: 'insert',
+			database: 'data',
+			table: 'Dog',
+			records: [{ id: 'dog-1', name: 'Buddy', breed: 'Dalmatian', age: 3, color: 'Black and White' }],
+		});
+
+		const got = await op<{ id: string; name: string; breed: string; age: number }[]>(ctx, {
+			operation: 'search_by_id',
+			database: 'data',
+			table: 'Dog',
+			ids: ['dog-1'],
+			get_attributes: ['id', 'name', 'breed', 'age', 'color'],
+		});
+		strictEqual(got.length, 1);
+		strictEqual(got[0].name, 'Buddy');
+		strictEqual(got[0].breed, 'Dalmatian');
+		strictEqual(got[0].age, 3);
+
+		await op(ctx, { operation: 'delete', database: 'data', table: 'Dog', ids: ['dog-1'] });
+
+		const afterDelete = await op<unknown[]>(ctx, {
+			operation: 'search_by_id',
+			database: 'data',
+			table: 'Dog',
+			ids: ['dog-1'],
+			get_attributes: ['id'],
+		});
+		deepStrictEqual(afterDelete, []);
+	});
+
+	void test('Next.js home page renders', async () => {
+		const res = await pageFetch(ctx, '/');
+		strictEqual(res.status, 200);
+		ok((res.headers.get('content-type') ?? '').includes('text/html'), 'expected an HTML response');
+		const html = await res.text();
+		ok(html.includes('Doggy Management System'), 'expected the home page heading');
+	});
+
+	void test('Next.js /dogs page renders', async () => {
+		const res = await pageFetch(ctx, '/dogs');
+		strictEqual(res.status, 200);
+		ok((res.headers.get('content-type') ?? '').includes('text/html'), 'expected an HTML response');
+	});
+});

--- a/integrationTests/tsconfig.json
+++ b/integrationTests/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"lib": ["ES2022"],
+		"types": ["node"],
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"noEmit": true,
+		"verbatimModuleSyntax": true
+	},
+	"include": ["**/*.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,150 +9,21 @@
 			"version": "0.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@harperfast/nextjs": "2.0.0",
-				"harper": "5.0.3",
+				"@harperfast/nextjs": "2.2.1",
+				"harper": "^5.0.10",
 				"next": "15.5.15",
 				"react": "18",
 				"react-dom": "18"
 			},
 			"devDependencies": {
 				"@harperdb/code-guidelines": "0.0.2",
+				"@harperfast/integration-testing": "^0.4.0",
+				"@types/node": "^22.0.0",
 				"eslint": "9.27.0",
 				"eslint-config-next": "15.3.3",
 				"eslint-config-prettier": "10.1.5",
-				"prettier": "3.5.3"
-			}
-		},
-		"../harper": {
-			"version": "5.0.3",
-			"extraneous": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/client-s3": "^3.1012.0",
-				"@aws-sdk/lib-storage": "3.1024.0",
-				"@datadog/pprof": "^5.11.1",
-				"@endo/static-module-record": "^1.1.2",
-				"@fastify/autoload": "^6.3.1",
-				"@fastify/compress": "^8.3.1",
-				"@fastify/cors": "^11.2.0",
-				"@fastify/static": "^9.0.0",
-				"@harperfast/extended-iterable": "^1.0.1",
-				"@harperfast/rocksdb-js": "^1.0.1",
-				"@turf/area": "6.5.0",
-				"@turf/boolean-contains": "6.5.0",
-				"@turf/boolean-disjoint": "6.5.0",
-				"@turf/boolean-equal": "6.5.0",
-				"@turf/circle": "6.5.0",
-				"@turf/difference": "6.5.0",
-				"@turf/distance": "6.5.0",
-				"@turf/helpers": "6.5.0",
-				"@turf/length": "6.5.0",
-				"alasql": "4.6.6",
-				"amaro": "^1.1.8",
-				"argon2": "0.44.0",
-				"asn1js": "3.0.7",
-				"cbor-x": "1.6.4",
-				"chalk": "4.1.2",
-				"chokidar": "^4.0.3",
-				"cli-progress": "3.12.0",
-				"clone": "2.1.2",
-				"dotenv": "^16.4.7",
-				"easy-ocsp": "1.3.1",
-				"fast-glob": "3.3.3",
-				"fastify": "^5.8.2",
-				"fastify-plugin": "^5.1.0",
-				"fs-extra": "11.3.4",
-				"graphql": "^16.10.0",
-				"graphql-http": "^1.22.4",
-				"gunzip-maybe": "1.4.2",
-				"human-readable-ids": "1.0.4",
-				"inquirer": "8.2.7",
-				"is-number": "7.0.0",
-				"joi": "17.13.3",
-				"json-bigint-fixes": "1.1.0",
-				"jsonata": "1.8.7",
-				"jsonwebtoken": "9.0.3",
-				"lmdb": "3.5.4",
-				"lodash": "^4.17.23",
-				"mathjs": "11.12.0",
-				"micromatch": "^4.0.8",
-				"minimist": "1.2.8",
-				"moment": "2.30.1",
-				"mqtt-packet": "~9.0.1",
-				"msgpackr": "1.11.9",
-				"needle": "3.5.0",
-				"node-forge": "^1.3.1",
-				"node-stream-zip": "1.15.0",
-				"node-unix-socket": "0.2.7",
-				"normalize-path": "^3.0.0",
-				"ora": "8.2.0",
-				"ordered-binary": "1.6.1",
-				"papaparse": "5.5.3",
-				"passport": "0.7.0",
-				"passport-http": "0.3.0",
-				"passport-local": "1.0.0",
-				"pino": "8.21.0",
-				"pkijs": "3.4.0",
-				"prompt": "1.3.0",
-				"properties-reader": "2.3.0",
-				"recursive-iterator": "3.3.0",
-				"semver": "7.7.4",
-				"send": "^1.2.0",
-				"ses": "^1.15.0",
-				"stream-chain": "2.2.5",
-				"stream-json": "1.9.1",
-				"systeminformation": "^5.31.4",
-				"tar-fs": "^3.1.2",
-				"ulidx": "0.5.0",
-				"uuid": "11.1.0",
-				"validate.js": "0.13.1",
-				"ws": "8.20.0",
-				"yaml": "2.8.3"
-			},
-			"bin": {
-				"harper": "dist/bin/harper.js"
-			},
-			"devDependencies": {
-				"@harperdb/code-guidelines": "^0.0.6",
-				"@types/fs-extra": "^11.0.4",
-				"@types/gunzip-maybe": "^1.4.3",
-				"@types/jsonwebtoken": "^9.0.10",
-				"@types/lodash": "^4.17.23",
-				"@types/micromatch": "^4.0.9",
-				"@types/mocha": "^10.0.10",
-				"@types/sinon": "^21.0.0",
-				"@types/tar-fs": "^2.0.4",
-				"@typescript-eslint/parser": "^8.48.1",
-				"axios": "1.14.0",
-				"chai": "^6.2.0",
-				"chai-as-promised": "^8.0.2",
-				"chai-integer": "^0.1.0",
-				"eventsource": "^3.0.5",
-				"globals": "^16.5.0",
-				"intercept-stdout": "0.1.2",
-				"mkcert": "^3.2.0",
-				"mocha": "^11.7.5",
-				"mqtt": "~4.3.8",
-				"oxlint": "^1.31.0",
-				"prettier": "~3.8.0",
-				"rewire": "^9.0.1",
-				"sinon": "^21.0.0",
-				"sinon-chai": "^4.0.1",
-				"supertest": "^7.1.4",
-				"tsx": "^4.20.6",
-				"typescript": "^5.8.2",
-				"typescript-eslint": "^8.45.0",
-				"undici": "^7.24.4",
-				"why-is-node-still-running": "^1.0.0"
-			},
-			"engines": {
-				"minimum-node": "20.0.0",
-				"node": ">=20"
-			},
-			"optionalDependencies": {
-				"bufferutil": "^4.0.9",
-				"segfault-handler": "^1.3.0",
-				"utf-8-validate": "^5.0.10"
+				"prettier": "3.5.3",
+				"typescript": "^5.6.0"
 			}
 		},
 		"node_modules/@agoric/babel-generator": {
@@ -217,44 +88,6 @@
 				"tslib": "^2.6.2"
 			}
 		},
-		"node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/is-array-buffer": "^2.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/util-buffer-from": "^2.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
 		"node_modules/@aws-crypto/sha256-browser": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
@@ -268,44 +101,6 @@
 				"@aws-sdk/util-locate-window": "^3.0.0",
 				"@smithy/util-utf8": "^2.0.0",
 				"tslib": "^2.6.2"
-			}
-		},
-		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/is-array-buffer": "^2.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/util-buffer-from": "^2.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@aws-crypto/sha256-js": {
@@ -342,104 +137,45 @@
 				"tslib": "^2.6.2"
 			}
 		},
-		"node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+		"node_modules/@aws-sdk/checksums": {
+			"version": "3.1000.2",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.2.tgz",
+			"integrity": "sha512-PIha+kauTbp6IRmOpYktPTrlfrrSqDVixvhO/EUOFOf62DPX81CaJoHJreuA1m9HYpSKyXf99BKjU1dvJPeUfw==",
 			"license": "Apache-2.0",
 			"dependencies": {
+				"@aws-crypto/crc32": "5.2.0",
+				"@aws-crypto/crc32c": "5.2.0",
+				"@aws-crypto/util": "5.2.0",
+				"@aws-sdk/core": "^3.974.18",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/is-array-buffer": "^2.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/util-buffer-from": "^2.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
+				"node": ">=20.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/client-s3": {
-			"version": "3.1035.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1035.0.tgz",
-			"integrity": "sha512-Bh1h96CjHMpxg6Rn2G4EE30YiiBh9w/7WmSZIfwLB0X/6lblaJcHggcryrq2uNN2Bx1/CNErMjTpGQzqhA7Rhg==",
+			"version": "3.1063.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1063.0.tgz",
+			"integrity": "sha512-ETn+vvmZVK1MmOZwVBXmWANpmD5iTbzojIqyEIoZ86qo+8oWy35S8QyQNE/ZDI+WHgMU1dS+VSYbpRl1QkEySg==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@aws-crypto/sha1-browser": "5.2.0",
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.974.4",
-				"@aws-sdk/credential-provider-node": "^3.972.35",
-				"@aws-sdk/middleware-bucket-endpoint": "^3.972.10",
-				"@aws-sdk/middleware-expect-continue": "^3.972.10",
-				"@aws-sdk/middleware-flexible-checksums": "^3.974.12",
-				"@aws-sdk/middleware-host-header": "^3.972.10",
-				"@aws-sdk/middleware-location-constraint": "^3.972.10",
-				"@aws-sdk/middleware-logger": "^3.972.10",
-				"@aws-sdk/middleware-recursion-detection": "^3.972.11",
-				"@aws-sdk/middleware-sdk-s3": "^3.972.33",
-				"@aws-sdk/middleware-ssec": "^3.972.10",
-				"@aws-sdk/middleware-user-agent": "^3.972.34",
-				"@aws-sdk/region-config-resolver": "^3.972.13",
-				"@aws-sdk/signature-v4-multi-region": "^3.996.21",
-				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/util-endpoints": "^3.996.8",
-				"@aws-sdk/util-user-agent-browser": "^3.972.10",
-				"@aws-sdk/util-user-agent-node": "^3.973.20",
-				"@smithy/config-resolver": "^4.4.17",
-				"@smithy/core": "^3.23.16",
-				"@smithy/eventstream-serde-browser": "^4.2.14",
-				"@smithy/eventstream-serde-config-resolver": "^4.3.14",
-				"@smithy/eventstream-serde-node": "^4.2.14",
-				"@smithy/fetch-http-handler": "^5.3.17",
-				"@smithy/hash-blob-browser": "^4.2.15",
-				"@smithy/hash-node": "^4.2.14",
-				"@smithy/hash-stream-node": "^4.2.14",
-				"@smithy/invalid-dependency": "^4.2.14",
-				"@smithy/md5-js": "^4.2.14",
-				"@smithy/middleware-content-length": "^4.2.14",
-				"@smithy/middleware-endpoint": "^4.4.31",
-				"@smithy/middleware-retry": "^4.5.4",
-				"@smithy/middleware-serde": "^4.2.19",
-				"@smithy/middleware-stack": "^4.2.14",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/node-http-handler": "^4.6.0",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.12",
-				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-body-length-browser": "^4.2.2",
-				"@smithy/util-body-length-node": "^4.2.3",
-				"@smithy/util-defaults-mode-browser": "^4.3.48",
-				"@smithy/util-defaults-mode-node": "^4.2.53",
-				"@smithy/util-endpoints": "^3.4.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-retry": "^4.3.3",
-				"@smithy/util-stream": "^4.5.24",
-				"@smithy/util-utf8": "^4.2.2",
-				"@smithy/util-waiter": "^4.2.16",
+				"@aws-sdk/core": "^3.974.18",
+				"@aws-sdk/credential-provider-node": "^3.972.52",
+				"@aws-sdk/middleware-flexible-checksums": "^3.974.27",
+				"@aws-sdk/middleware-sdk-s3": "^3.972.48",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.32",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/core": "^3.24.6",
+				"@smithy/fetch-http-handler": "^5.4.6",
+				"@smithy/node-http-handler": "^4.7.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -447,37 +183,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/core": {
-			"version": "3.974.4",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.4.tgz",
-			"integrity": "sha512-EbVgyzQ83/Lf6oh1O4vYY47tuYw3Aosthh865LNU77KyotKz+uvEBNmsl/bSVS/vG+IU39mCqcOHrnhmhF4lug==",
+			"version": "3.974.18",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.18.tgz",
+			"integrity": "sha512-JDYCPI0j7zGrzXTDFsLB346cxss7J/AxH7+O0MzWlqppJBEyB9Qe6TQXRL6iwLUo/xZkNv9KFmBL2hqElmwW0g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/xml-builder": "^3.972.18",
-				"@smithy/core": "^3.23.16",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/signature-v4": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.12",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-retry": "^4.3.3",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/crc64-nvme": {
-			"version": "3.972.7",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.7.tgz",
-			"integrity": "sha512-QUagVVBbC8gODCF6e1aV0mE2TXWB9Opz4k8EJFdNrujUVQm5R4AjJa1mpOqzwOuROBzqJU9zawzig7M96L8Ejg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/types": "^3.973.11",
+				"@aws-sdk/xml-builder": "^3.972.28",
+				"@aws/lambda-invoke-store": "^0.2.2",
+				"@smithy/core": "^3.24.6",
+				"@smithy/signature-v4": "^5.4.6",
+				"@smithy/types": "^4.14.3",
+				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -485,15 +202,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.972.30",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.30.tgz",
-			"integrity": "sha512-dHpeqa29a0cBYq/h59IC2EK3AphLY96nKy4F35kBtiz9GuKDc32UYRTgjZaF8uuJCnqgw9omUZKR+9myyDHC2A==",
+			"version": "3.972.44",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.44.tgz",
+			"integrity": "sha512-3hKJVrZ7bqXzDAXCQp+OaQ1ASN+vWstaNuEH418wQVl//cRZhqhfR9Bjk1qIWmgUGe8/D3gdO73PgidRj378EQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.4",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/core": "^3.974.18",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -501,20 +218,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.972.32",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.32.tgz",
-			"integrity": "sha512-A+ZTT//Mswkf9DFEM6XlngwOtYdD8X4CUcoZ2wdpgI8cCs9mcGeuhgTwbGJvealub/MeONOaUr3FbRPMKmTDjg==",
+			"version": "3.972.46",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.46.tgz",
+			"integrity": "sha512-VhwC9pGAZHhiQ2xSViyOPDFqvr9aRxGCAXZtADsUhU3R65nad7y//CwynE6mQnWNR+suRlqE79W36IVayL+m1g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.4",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/fetch-http-handler": "^5.3.17",
-				"@smithy/node-http-handler": "^4.6.0",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.12",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-stream": "^4.5.24",
+				"@aws-sdk/core": "^3.974.18",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/core": "^3.24.6",
+				"@smithy/fetch-http-handler": "^5.4.6",
+				"@smithy/node-http-handler": "^4.7.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -522,24 +236,23 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.972.34",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.34.tgz",
-			"integrity": "sha512-MoRc7tLnx3JpFkV2R826enEfBUVN8o9Cc7y3hnbMwiWzL/VJhgfxRQzHkEL9vWorMWP7tibltsRcLoid9fsVdw==",
+			"version": "3.972.50",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.50.tgz",
+			"integrity": "sha512-09Xi6ovxiK42+De/qBGF71sT5F2bWgYM+1fFyDwSOpy1xpsQ5R/naIu7MVDpH6Dic36QNc8dAv4KADtMGK2JYg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.4",
-				"@aws-sdk/credential-provider-env": "^3.972.30",
-				"@aws-sdk/credential-provider-http": "^3.972.32",
-				"@aws-sdk/credential-provider-login": "^3.972.34",
-				"@aws-sdk/credential-provider-process": "^3.972.30",
-				"@aws-sdk/credential-provider-sso": "^3.972.34",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.34",
-				"@aws-sdk/nested-clients": "^3.997.2",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/credential-provider-imds": "^4.2.14",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/core": "^3.974.18",
+				"@aws-sdk/credential-provider-env": "^3.972.44",
+				"@aws-sdk/credential-provider-http": "^3.972.46",
+				"@aws-sdk/credential-provider-login": "^3.972.49",
+				"@aws-sdk/credential-provider-process": "^3.972.44",
+				"@aws-sdk/credential-provider-sso": "^3.972.49",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.49",
+				"@aws-sdk/nested-clients": "^3.997.17",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/core": "^3.24.6",
+				"@smithy/credential-provider-imds": "^4.3.7",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -547,18 +260,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-login": {
-			"version": "3.972.34",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.34.tgz",
-			"integrity": "sha512-XVSklkRRQ/CQDmv3VVFdZRl5hTFgncFhZrLyi0Ai4LZk5o3jpY5HIfuTK7ad7tixPKa+iQmL9+vg9qNyYZB+nw==",
+			"version": "3.972.49",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.49.tgz",
+			"integrity": "sha512-EfJF/1Fh9mI4pZyoheU2RY9xUhTcugIZNkD63+orXMkYj/QXacJNbKVDUK90Yv5hE+aX+rt9J/EZ9Qr3vKOa7g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.4",
-				"@aws-sdk/nested-clients": "^3.997.2",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/core": "^3.974.18",
+				"@aws-sdk/nested-clients": "^3.997.17",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -566,22 +277,21 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.972.35",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.35.tgz",
-			"integrity": "sha512-nVrY7AdGfzYgAa/jd9m06p3ES7QQDaB7zN9c+vXnVXxBRkAs9MjRDPB5AKogWuC6phddltfvHGFqLDJmyU9u/A==",
+			"version": "3.972.52",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.52.tgz",
+			"integrity": "sha512-7QX+PbyiWBEOVipJq8Nke/TqXT6lAPLE7fvTaopa39/IVWuLfS+Fzdy71sZJONf/mLGgmtj6aU17+REw3+aRrw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "^3.972.30",
-				"@aws-sdk/credential-provider-http": "^3.972.32",
-				"@aws-sdk/credential-provider-ini": "^3.972.34",
-				"@aws-sdk/credential-provider-process": "^3.972.30",
-				"@aws-sdk/credential-provider-sso": "^3.972.34",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.34",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/credential-provider-imds": "^4.2.14",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/credential-provider-env": "^3.972.44",
+				"@aws-sdk/credential-provider-http": "^3.972.46",
+				"@aws-sdk/credential-provider-ini": "^3.972.50",
+				"@aws-sdk/credential-provider-process": "^3.972.44",
+				"@aws-sdk/credential-provider-sso": "^3.972.49",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.49",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/core": "^3.24.6",
+				"@smithy/credential-provider-imds": "^4.3.7",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -589,16 +299,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.972.30",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.30.tgz",
-			"integrity": "sha512-McJPomNTSEo+C6UA3Zq6pFrcyTUaVsoPPBOvbOHAoIFPc8Z2CMLndqFJOnB+9bVFiBTWQLutlVGmrocBbvv4MQ==",
+			"version": "3.972.44",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.44.tgz",
+			"integrity": "sha512-V+UUhZpRP7QDRhi+qgBDisM9tUBnYmMje8Bk77A6MZsfeGeGdMsQXmaHP1CDYFcept0o/Rz5g2Y0TMeVlG9dzg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.4",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/core": "^3.974.18",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -606,18 +315,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.972.34",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.34.tgz",
-			"integrity": "sha512-WngYb2K+/yhkDOmDfAOjoCa9Ja3he0DZiAraboKwgWoVRkajDIcDYBCVbUTxtTUldvQoe7VvHLTrBNxvftN1aQ==",
+			"version": "3.972.49",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.49.tgz",
+			"integrity": "sha512-9QqOYGuh5tZ76OzaT68kwI78AH+5lS/uZGGvkfxb3fc8FzRrIz2jOufNTliEBEeSAwmgK2rWLNsK+IB3zbtNPA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.4",
-				"@aws-sdk/nested-clients": "^3.997.2",
-				"@aws-sdk/token-providers": "3.1035.0",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/core": "^3.974.18",
+				"@aws-sdk/nested-clients": "^3.997.17",
+				"@aws-sdk/token-providers": "3.1063.0",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -625,17 +333,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.972.34",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.34.tgz",
-			"integrity": "sha512-5KLUH+XmSNRj6amJiJSrPsCxU5l/PYDfxyqPa1MxWhHoQC3sxvGPrSib3IE+HQlfRA4e2kO0bnJy7HJdjvpuuA==",
+			"version": "3.972.49",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.49.tgz",
+			"integrity": "sha512-IYx1lN38MnnPXv+NBLpuATu0cZakbZ321TAfjW+aVkw7HIJF38YnEwdeEO55MSl3pl7hIX1IvvnD6EmnAzmAJw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.4",
-				"@aws-sdk/nested-clients": "^3.997.2",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/core": "^3.974.18",
+				"@aws-sdk/nested-clients": "^3.997.17",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -643,15 +350,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/lib-storage": {
-			"version": "3.1024.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1024.0.tgz",
-			"integrity": "sha512-5zZSYI8VncyiatvEn+UqElvgX14NKEc+3a+aeMyMzqKuYgDCFd97KGdbqAXEgnfEiTNK0QgSecFC6PUMAsE3xg==",
+			"version": "3.1045.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1045.0.tgz",
+			"integrity": "sha512-F7dp2ST/83Iz6JTMMmUYEXxg7R1JDewfvzJeWWiDTwe0vLsg67JTN7OsBe6G8DWYbLQ+EyPWkyc3oFnxOjCVfg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/middleware-endpoint": "^4.4.28",
-				"@smithy/protocol-http": "^5.3.12",
-				"@smithy/smithy-client": "^4.12.8",
-				"@smithy/types": "^4.13.1",
+				"@smithy/middleware-endpoint": "^4.4.32",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/smithy-client": "^4.12.13",
+				"@smithy/types": "^4.14.1",
 				"buffer": "5.6.0",
 				"events": "3.3.0",
 				"stream-browserify": "3.0.0",
@@ -661,120 +368,16 @@
 				"node": ">=20.0.0"
 			},
 			"peerDependencies": {
-				"@aws-sdk/client-s3": "^3.1024.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-bucket-endpoint": {
-			"version": "3.972.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.10.tgz",
-			"integrity": "sha512-Vbc2frZH7wXlMNd+ZZSXUEs/l1Sv8Jj4zUnIfwrYF5lwaLdXHZ9xx4U3rjUcaye3HRhFVc+E5DbBxpRAbB16BA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/util-arn-parser": "^3.972.3",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-config-provider": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-expect-continue": {
-			"version": "3.972.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.10.tgz",
-			"integrity": "sha512-2Yn0f1Qiq/DjxYR3wfI3LokXnjOhFM7Ssn4LTdFDIxRMCE6I32MAsVnhPX1cUZsuVA9tiZtwwhlSLAtFGxAZlQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
+				"@aws-sdk/client-s3": "^3.1045.0"
 			}
 		},
 		"node_modules/@aws-sdk/middleware-flexible-checksums": {
-			"version": "3.974.12",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.12.tgz",
-			"integrity": "sha512-v7n0//P95g+UnmyjCpJkDJFB+EP/9Wx/fQJC5BEiK9Y7VHgmhh6RNPVbqDYz9gsz8mXnxzyYt3tCEVJ1kzo01w==",
+			"version": "3.974.27",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.27.tgz",
+			"integrity": "sha512-bZqezPLdllFC4VAeV/f+EIc/hz56ab3TD/+4zNCgOgmG5ZHAE5dMHrX1gtTwdcQXbPr3KR7x3zTC3zuCTE6+ng==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-crypto/crc32": "5.2.0",
-				"@aws-crypto/crc32c": "5.2.0",
-				"@aws-crypto/util": "5.2.0",
-				"@aws-sdk/core": "^3.974.4",
-				"@aws-sdk/crc64-nvme": "^3.972.7",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/is-array-buffer": "^4.2.2",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-stream": "^4.5.24",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-host-header": {
-			"version": "3.972.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
-			"integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-location-constraint": {
-			"version": "3.972.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.10.tgz",
-			"integrity": "sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-logger": {
-			"version": "3.972.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
-			"integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-recursion-detection": {
-			"version": "3.972.11",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
-			"integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@aws/lambda-invoke-store": "^0.2.2",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/checksums": "^3.1000.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -782,57 +385,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-sdk-s3": {
-			"version": "3.972.33",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.33.tgz",
-			"integrity": "sha512-n8Eh/+kq3u/EodLr8n6sQupu03QGjf122RHXCTGLaHSkavz/2beSKpRlq2oDgfmJZNkAkWF113xbyaUmyOd+YA==",
+			"version": "3.972.48",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.48.tgz",
+			"integrity": "sha512-MRTqx8wD/T3REt6LTT3/yN8rrp6+xIHrbUekkDYJTYWVch70mwtdJBovR4qKJz1jIPlbN+9R/Sn6R04BfsglzA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.4",
-				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/util-arn-parser": "^3.972.3",
-				"@smithy/core": "^3.23.16",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/signature-v4": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.12",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-config-provider": "^4.2.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-stream": "^4.5.24",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-ssec": {
-			"version": "3.972.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.10.tgz",
-			"integrity": "sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.972.34",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.34.tgz",
-			"integrity": "sha512-jrmJHyYlTQocR7H4VhvSFhaoedMb2rmlOTvFWD6tNBQ/EVQhTsrNfQUYFuPiOc2wUGxbm5LgCHtnvVmCPgODHw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.4",
-				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/util-endpoints": "^3.996.8",
-				"@smithy/core": "^3.23.16",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-retry": "^4.3.3",
+				"@aws-sdk/core": "^3.974.18",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.32",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -840,65 +402,20 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients": {
-			"version": "3.997.2",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.2.tgz",
-			"integrity": "sha512-uGGQO08YetrqfInOKG5atRMrCDRQWRuZ9gGfKY6svPmuE4K7ac+XcbCkpWpjcA7yCYsBaKB/Nly4XKgPXUO1PA==",
+			"version": "3.997.17",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.17.tgz",
+			"integrity": "sha512-lDRgraoTfKRawUyc176Ow93mrNrOho/x+EoK4C+lKU+vKkHWhNhzvSMVAx0WEJUJoeQxxDN5ZdKMfiGEyNejig==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.974.4",
-				"@aws-sdk/middleware-host-header": "^3.972.10",
-				"@aws-sdk/middleware-logger": "^3.972.10",
-				"@aws-sdk/middleware-recursion-detection": "^3.972.11",
-				"@aws-sdk/middleware-user-agent": "^3.972.34",
-				"@aws-sdk/region-config-resolver": "^3.972.13",
-				"@aws-sdk/signature-v4-multi-region": "^3.996.21",
-				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/util-endpoints": "^3.996.8",
-				"@aws-sdk/util-user-agent-browser": "^3.972.10",
-				"@aws-sdk/util-user-agent-node": "^3.973.20",
-				"@smithy/config-resolver": "^4.4.17",
-				"@smithy/core": "^3.23.16",
-				"@smithy/fetch-http-handler": "^5.3.17",
-				"@smithy/hash-node": "^4.2.14",
-				"@smithy/invalid-dependency": "^4.2.14",
-				"@smithy/middleware-content-length": "^4.2.14",
-				"@smithy/middleware-endpoint": "^4.4.31",
-				"@smithy/middleware-retry": "^4.5.4",
-				"@smithy/middleware-serde": "^4.2.19",
-				"@smithy/middleware-stack": "^4.2.14",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/node-http-handler": "^4.6.0",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.12",
-				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-body-length-browser": "^4.2.2",
-				"@smithy/util-body-length-node": "^4.2.3",
-				"@smithy/util-defaults-mode-browser": "^4.3.48",
-				"@smithy/util-defaults-mode-node": "^4.2.53",
-				"@smithy/util-endpoints": "^3.4.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-retry": "^4.3.3",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/region-config-resolver": {
-			"version": "3.972.13",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
-			"integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/config-resolver": "^4.4.17",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/core": "^3.974.18",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.32",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/core": "^3.24.6",
+				"@smithy/fetch-http-handler": "^5.4.6",
+				"@smithy/node-http-handler": "^4.7.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -906,16 +423,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/signature-v4-multi-region": {
-			"version": "3.996.21",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.21.tgz",
-			"integrity": "sha512-3EpT+C0QdmTMB5aVeJ5odWSLt9vg2oGzUXl1xvUazKGlkr9OBYnegNWqhhjGgZdv8RmSi5eS8nqqB+euNP2aqA==",
+			"version": "3.996.32",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.32.tgz",
+			"integrity": "sha512-llvApLcsWtmRFhG2wT3WIp1CmDeRaIYutqty1ZZXoMzK7TiJ6MOLOimk9eXUS8PwgG4ew4pa4QAbt0lfhn++1w==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/middleware-sdk-s3": "^3.972.33",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/signature-v4": "^5.3.14",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/signature-v4": "^5.4.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -923,17 +438,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.1035.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1035.0.tgz",
-			"integrity": "sha512-E6IO3Cn+OzBe6Sb5pnubd5Y8qSUMAsVKkD5QSwFfIx5fV1g5SkYwUDRDyPlm90RuIVcCo28wpMJU6W8wXH46Aw==",
+			"version": "3.1063.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1063.0.tgz",
+			"integrity": "sha512-nYDaWWdzjKiDP5xj8k4oUgcYd4WPgzfAOgdU5vJsaqH/07Dfvm7ffisHCFJ+NEl7kUC9JEIUxh0kznvenbo3NQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.4",
-				"@aws-sdk/nested-clients": "^3.997.2",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/core": "^3.974.18",
+				"@aws-sdk/nested-clients": "^3.997.17",
+				"@aws-sdk/types": "^3.973.11",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -941,40 +455,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/types": {
-			"version": "3.973.8",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
-			"integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+			"version": "3.973.11",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.11.tgz",
+			"integrity": "sha512-YjS0qFuECClRh4qhEyW8XagW0fwEPBeZ1cfsW/gU73Kh/ExFILxbzxOfPCmzF/2DwEvhvsHYt0b0qnvStwKYrg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-arn-parser": {
-			"version": "3.972.3",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
-			"integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.996.8",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
-			"integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
-				"@smithy/util-endpoints": "^3.4.2",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -982,62 +468,25 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-locate-window": {
-			"version": "3.965.5",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
-			"integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+			"version": "3.965.6",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.6.tgz",
+			"integrity": "sha512-ZfHjfwSzeXj+Lg9AK5ZNmeDkXev6V+w2tn1t4kgDdRtUaRCthepTQiFwbD06EF9oNGH4LaLg+Mb6U16Ypv5bSw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-user-agent-browser": {
-			"version": "3.972.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
-			"integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/types": "^4.14.1",
-				"bowser": "^2.11.0",
-				"tslib": "^2.6.2"
-			}
-		},
-		"node_modules/@aws-sdk/util-user-agent-node": {
-			"version": "3.973.20",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.20.tgz",
-			"integrity": "sha512-owEqyKr0z5hWwk+uHwudwNhyFMZ9f9eSWr/k/XD6yeDCI7hHyc56s4UOY1iBQmoramTbdAY4UCuLLEuKmjVXrg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/middleware-user-agent": "^3.972.34",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-config-provider": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			},
-			"peerDependencies": {
-				"aws-crt": ">=1.0.0"
-			},
-			"peerDependenciesMeta": {
-				"aws-crt": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@aws-sdk/xml-builder": {
-			"version": "3.972.18",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.18.tgz",
-			"integrity": "sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==",
+			"version": "3.972.28",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.28.tgz",
+			"integrity": "sha512-lI/l3c/vPvsxmspzV63NfS3x9q4CkMmdhJy4QiM+NThAufVkDvi/PZZQ6xETnICL0UD7jI808pY83gllf86RFg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"fast-xml-parser": "5.5.8",
+				"@smithy/types": "^4.14.3",
+				"fast-xml-parser": "5.7.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1809,10 +1258,35 @@
 			"integrity": "sha512-sSAYhQca3rDWtQUHSAPeO7axFIUJOI6hn1gjRC5APVE1a90tuyT8f5WIgRsFhhWA7htNkju2veB9eWL6YHi/Lw==",
 			"license": "Apache-2.0"
 		},
+		"node_modules/@harperfast/integration-testing": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@harperfast/integration-testing/-/integration-testing-0.4.0.tgz",
+			"integrity": "sha512-mps3GG7/iS34XI0STlslE5sT7RXFUJnyhlRgNrTccrUd3230VqplW3+pXUhdhlU6OIC+r1auqA1sM0PFrGZKrA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tar-fs": "3.1.2"
+			},
+			"bin": {
+				"harper-integration-test-run": "dist/run.js",
+				"harper-integration-test-setup-loopback": "scripts/setup-loopback.sh"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"peerDependencies": {
+				"harper": "^5.0.0"
+			},
+			"peerDependenciesMeta": {
+				"harper": {
+					"optional": false
+				}
+			}
+		},
 		"node_modules/@harperfast/nextjs": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@harperfast/nextjs/-/nextjs-2.0.0.tgz",
-			"integrity": "sha512-klGY/H/udQnmvyKaBIIiEYxlr+Vta1lpevMDTHdjOqqfCFYIgNdcWv9AT9bEA0v62kF/WkFNgZivkzr+HY6hFQ==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@harperfast/nextjs/-/nextjs-2.2.1.tgz",
+			"integrity": "sha512-NjANKwNQe88ADtqM8Lrcb19dHO85rJujDcEY9NHV9lsVynvJiH4zGtTmkl7fPKH9AxQnxyKqsG662QEdH9VGhg==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20"
@@ -1827,33 +1301,36 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js/-/rocksdb-js-1.0.1.tgz",
-			"integrity": "sha512-XqSdZC8ChvqBcOjTAQafmVJaVKf4govEwcCiiqAOJ35cUCU8jcM6MnuPbx7mbQRQ39qecHpGewaDxfIM1LIJFQ==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js/-/rocksdb-js-1.4.2.tgz",
+			"integrity": "sha512-wQ0buhmNVcw6jPn5VOoYDsGmO1IAmtithcSgaKrnBRicf+ATvQSCB1I7ljEBuqqzWG6HcJXeCgPhFpas3kRwOw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@harperfast/extended-iterable": "1.0.3",
-				"msgpackr": "1.11.9",
+				"msgpackr": "2.0.1",
 				"ordered-binary": "1.6.1"
+			},
+			"bin": {
+				"rocksdb-js": "bin/rocksdb-js.mjs"
 			},
 			"engines": {
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@harperfast/rocksdb-js-darwin-arm64": "1.0.1",
-				"@harperfast/rocksdb-js-darwin-x64": "1.0.1",
-				"@harperfast/rocksdb-js-linux-arm64-glibc": "1.0.1",
-				"@harperfast/rocksdb-js-linux-arm64-musl": "1.0.1",
-				"@harperfast/rocksdb-js-linux-x64-glibc": "1.0.1",
-				"@harperfast/rocksdb-js-linux-x64-musl": "1.0.1",
-				"@harperfast/rocksdb-js-win32-arm64": "1.0.1",
-				"@harperfast/rocksdb-js-win32-x64": "1.0.1"
+				"@harperfast/rocksdb-js-darwin-arm64": "1.4.2",
+				"@harperfast/rocksdb-js-darwin-x64": "1.4.2",
+				"@harperfast/rocksdb-js-linux-arm64-glibc": "1.4.2",
+				"@harperfast/rocksdb-js-linux-arm64-musl": "1.4.2",
+				"@harperfast/rocksdb-js-linux-x64-glibc": "1.4.2",
+				"@harperfast/rocksdb-js-linux-x64-musl": "1.4.2",
+				"@harperfast/rocksdb-js-win32-arm64": "1.4.2",
+				"@harperfast/rocksdb-js-win32-x64": "1.4.2"
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-darwin-arm64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-arm64/-/rocksdb-js-darwin-arm64-1.0.1.tgz",
-			"integrity": "sha512-b7Tn2TZgQ23iwIv6BQHnaXUgoUSaJ7A26GW0kjhTq8ylK7YzdtbFW1pSkAIQU5e9mQIXhbo0/N+u+MLCvafGgQ==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-arm64/-/rocksdb-js-darwin-arm64-1.4.2.tgz",
+			"integrity": "sha512-qQyv8BNCjvZQayhoTd7iqt1CLNEFHfqe8/SDZk8ztAR0ZAIyHIFkmNnaQ/Izn6p3HrNCRp6lNdwO4TKPWHj4SQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1867,9 +1344,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-darwin-x64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-x64/-/rocksdb-js-darwin-x64-1.0.1.tgz",
-			"integrity": "sha512-VswnRKHvvbgheb/PNy4ZtfNdLvqQ0eUPwY5jxvbgMZy+yD030FO84IbOvBaKl7Z8u2GpI2p9wG9/qwLtmz8XaQ==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-darwin-x64/-/rocksdb-js-darwin-x64-1.4.2.tgz",
+			"integrity": "sha512-cPCsB7IVeuDhNjFcb/nqUkwtBI9BlaFNecJ/OjkG8hUpYAhd5rdNHFMt1vpu4sAYFaorFrMZoNKGbq43v14+hQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1883,9 +1360,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-arm64-glibc": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-glibc/-/rocksdb-js-linux-arm64-glibc-1.0.1.tgz",
-			"integrity": "sha512-rKCGOpdrOVqCOahWAGk+v3aCRNV0acUwJ+EBnEXMlsiMubpFt0wxQg+EWIhWaOyZQoQ/omCSXzRLXBS/G0L6HA==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-glibc/-/rocksdb-js-linux-arm64-glibc-1.4.2.tgz",
+			"integrity": "sha512-NquwD+7Gxu3BYAIQhvSThjIRlZRBieDZKXGEmrc0gfcxcORbgOjMCdxDzhjF6l1nR4ODlfJfbKqGyF8JtmnIjA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1899,9 +1376,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-arm64-musl": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-musl/-/rocksdb-js-linux-arm64-musl-1.0.1.tgz",
-			"integrity": "sha512-ylJruv9WBvT4CACvXlLW610O53z3d2otfpnRSOcGBQVzZsGbd9n1L1cEZbAiiyJPBCFk5tBCueU6n7w6Mnh4Qg==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-arm64-musl/-/rocksdb-js-linux-arm64-musl-1.4.2.tgz",
+			"integrity": "sha512-hp2IOXYBvloJEkZ/+bCI/AsQPtzza51Pkz+U+JkaAaayZ6+zsXdVp5GuGYPnCiH4O6QnOihKkgBW8msFhR0ogA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1915,9 +1392,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-x64-glibc": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-glibc/-/rocksdb-js-linux-x64-glibc-1.0.1.tgz",
-			"integrity": "sha512-bx3q7VYPWyq1HhhhHIEqEMPIRR1DHn0VEuOmyrHgxaaRhpk21TECSgQDGe1DZYmppJfvj6IRI5pdfQjJL/pZNw==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-glibc/-/rocksdb-js-linux-x64-glibc-1.4.2.tgz",
+			"integrity": "sha512-zEkBHRoLanN9MTVY1mFRGDdAGyXBUrk962xvtf0sGj/wIK2M3c2KL39FftWHgtm/BHA3uGHssWk6B7O2O/Dlig==",
 			"cpu": [
 				"x64"
 			],
@@ -1931,9 +1408,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-linux-x64-musl": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-musl/-/rocksdb-js-linux-x64-musl-1.0.1.tgz",
-			"integrity": "sha512-nwoCS1/k7a43NmrKk1bPOu5V/lkENVs6fXGh4y0mgQfjcQ+csJhzXnlFQaE4RTSD0DLWuob7EoBaA0ipF5xLJQ==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-linux-x64-musl/-/rocksdb-js-linux-x64-musl-1.4.2.tgz",
+			"integrity": "sha512-K7y1CC+LJma2E+wEqFq67jk7+hZW+oPdKcqxyDxrIRKO3jyn0Dtr/fwQf3cFuU8cRnZBmZTAcnr5LeNJrUuYRw==",
 			"cpu": [
 				"x64"
 			],
@@ -1947,9 +1424,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-win32-arm64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-arm64/-/rocksdb-js-win32-arm64-1.0.1.tgz",
-			"integrity": "sha512-h7VYXXa2pGgyidCgfRdJIGxcAmcJVtO5lQjxO3WH5qpknm7+D0arZg8ebDyicgqZkb+uN/zi0blIi6z1bc6f6Q==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-arm64/-/rocksdb-js-win32-arm64-1.4.2.tgz",
+			"integrity": "sha512-xc4oav0zTLfnjBIan1wlgB3g0NeWrzUPxR0Vq5HkLc4BGyAlPql+v1FwtQ4X6AwcAOHnS/QeYSGDQOZn6Ac1Ow==",
 			"cpu": [
 				"arm64"
 			],
@@ -1963,9 +1440,9 @@
 			}
 		},
 		"node_modules/@harperfast/rocksdb-js-win32-x64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-x64/-/rocksdb-js-win32-x64-1.0.1.tgz",
-			"integrity": "sha512-Ikxl3CMsRutsfpaGX2JU9LLPH6tUcmMD5id5gzaNj2LE0O7ApJYX/ROqe21B6x8vDfxRk77qb8fcmvPHojNQXQ==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@harperfast/rocksdb-js-win32-x64/-/rocksdb-js-win32-x64-1.4.2.tgz",
+			"integrity": "sha512-60vqTYJdw0ysvHeFHoxZ/sHNesdfvri+jWIyU5TTua2s20LmLZ4hKLglnsa0LP7/IA5JutZsxJiyUUMCoG3PDw==",
 			"cpu": [
 				"x64"
 			],
@@ -1976,6 +1453,15 @@
 			],
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@harperfast/rocksdb-js/node_modules/msgpackr": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.1.tgz",
+			"integrity": "sha512-9J+tqTEsbHqY8YohazYgty7LgerFIWxvMLpUjqETSmjHojtJm2WnX2kK/2a1fLI7CO7ERP1YSEUXMucz4j+yBA==",
+			"license": "MIT",
+			"optionalDependencies": {
+				"msgpackr-extract": "^3.0.2"
 			}
 		},
 		"node_modules/@humanfs/core": {
@@ -2567,9 +2053,9 @@
 			}
 		},
 		"node_modules/@lmdb/lmdb-darwin-arm64": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-3.5.4.tgz",
-			"integrity": "sha512-Kk4Kz3iyu1QiLsLZBS9Af1eSKUC8VR2T+/jyE2iAyuGw2VwK08pp5iTbZnXn6sWu0LogO/RFktMxOjiDA2sS3w==",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-3.5.5.tgz",
+			"integrity": "sha512-hcSIUgSblRtwEuPzV/88cTbEPxaWfxVSrTaMIVUreyAA02ysE3S9tsiQdmT7KNmUaXlwgRGs+x+GaVDCuk7Prg==",
 			"cpu": [
 				"arm64"
 			],
@@ -2580,9 +2066,9 @@
 			]
 		},
 		"node_modules/@lmdb/lmdb-darwin-x64": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-3.5.4.tgz",
-			"integrity": "sha512-BEe5Rp3trn26oxoXOVL5HVDoiYmjUDwr8NRPkBOdUdCSBEorKI+7JrZLRKAdxO+G6cGQLgseXk0gR7qIQa7aGw==",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-3.5.5.tgz",
+			"integrity": "sha512-cLlp9ypk3W9Hr4fuTYwg1kL2vPfz887v9NXiHQE1raSKtJ8/hnghekqUu62wUQdQPgThLV8Om+Ran08wWuM/3w==",
 			"cpu": [
 				"x64"
 			],
@@ -2593,9 +2079,9 @@
 			]
 		},
 		"node_modules/@lmdb/lmdb-linux-arm": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-3.5.4.tgz",
-			"integrity": "sha512-SGbFR7816uBcTHc2ZY4S6WyOkl9bICnzqTQd2Mv4V/j24cfds88xx2nC6cm/y8zGQL7Ds31YF/5NGxjgcdM5Hw==",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-3.5.5.tgz",
+			"integrity": "sha512-eDeK9vZww0dIXlRCZa7pvbEXSUpUNIJKUs13FxDzazL8CRLDLggbeirm5m0hZvJcRgZzTYGESE8UUEBqHcdZ9Q==",
 			"cpu": [
 				"arm"
 			],
@@ -2606,9 +2092,9 @@
 			]
 		},
 		"node_modules/@lmdb/lmdb-linux-arm64": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-3.5.4.tgz",
-			"integrity": "sha512-cUXEengO8o60v1SWerJTH4/RH4U3+9jC0/4njp2Z9NdmvaGzhKsbRM2wpXuRYrN8tytsoJCg0SvWEWwHAwLbCA==",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-3.5.5.tgz",
+			"integrity": "sha512-tn8KSYdvX5sietpuGyJJSXocvQQtWlenzquap/Mzr+wWx5jrjK5I3nEAIMFxvTtuMMrpPTGHGNuE/Hanh3o0EQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -2619,9 +2105,9 @@
 			]
 		},
 		"node_modules/@lmdb/lmdb-linux-x64": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-3.5.4.tgz",
-			"integrity": "sha512-Gxq8jpgOWXwd0PUR+c9R2Ik1/uBnGd5GMIIzRRDqABCkvmjtC3KWcyhesV9jSPCz759isl0NlbsstZ2oyvk8lA==",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-3.5.5.tgz",
+			"integrity": "sha512-o6VRcJjZ6Zc67MnymLEa3AtbYSreFzm6Um6LMHh4lkynlE5Qk/XUHXU2beTZBdB3QuZBiMoXO2gjPSgP0tYUKg==",
 			"cpu": [
 				"x64"
 			],
@@ -2632,9 +2118,9 @@
 			]
 		},
 		"node_modules/@lmdb/lmdb-win32-arm64": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-arm64/-/lmdb-win32-arm64-3.5.4.tgz",
-			"integrity": "sha512-pKv1DJ1bPZAaHkdFsSz5IDfUG8x9vntgquXF9/Dm2xuupcIe/EkLzylpoBxppFVK5vzbV561Dq26jNY2fIMA7g==",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-arm64/-/lmdb-win32-arm64-3.5.5.tgz",
+			"integrity": "sha512-k0k/CwywhymTAJT7Uj5PdehH31Vem2ov/Jp0rn5McuJEHgzj7vbE0cmnByhjrQv+VeHLALI8wUZNicqwocPB4Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -2645,9 +2131,9 @@
 			]
 		},
 		"node_modules/@lmdb/lmdb-win32-x64": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-3.5.4.tgz",
-			"integrity": "sha512-JF1BmLCm9kGEVZgYmJq43zeQVdHVgAJnTi/NURWEsy6L1ZrrlSmdltS+D17QN4LODwf+1LMXAA9auIZVXtWwzw==",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-3.5.5.tgz",
+			"integrity": "sha512-dkV3r04ro8MfhBaPj4ZsARy0LIP3sK+rm2LAuVe2QLCepBIpSzRx8p8RLWfRfkKV5YNyJ3c0NUJxGNMqtTB6Fg==",
 			"cpu": [
 				"x64"
 			],
@@ -2667,9 +2153,9 @@
 			}
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
-			"integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+			"integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -2680,9 +2166,9 @@
 			]
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
-			"integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+			"integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
 			"cpu": [
 				"x64"
 			],
@@ -2693,9 +2179,9 @@
 			]
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
-			"integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+			"integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
 			"cpu": [
 				"arm"
 			],
@@ -2706,9 +2192,9 @@
 			]
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
-			"integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+			"integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
 			"cpu": [
 				"arm64"
 			],
@@ -2719,9 +2205,9 @@
 			]
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
-			"integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+			"integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
 			"cpu": [
 				"x64"
 			],
@@ -2732,9 +2218,9 @@
 			]
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
-			"integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+			"integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
 			"cpu": [
 				"x64"
 			],
@@ -2913,6 +2399,18 @@
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
+		"node_modules/@nodable/entities": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+			"integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodable"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3008,63 +2506,14 @@
 			"integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/@smithy/chunked-blob-reader": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.2.tgz",
-			"integrity": "sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/chunked-blob-reader-native": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.3.tgz",
-			"integrity": "sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/util-base64": "^4.3.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/config-resolver": {
-			"version": "4.4.17",
-			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
-			"integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-config-provider": "^4.2.2",
-				"@smithy/util-endpoints": "^3.4.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
 		"node_modules/@smithy/core": {
-			"version": "3.23.17",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
-			"integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
+			"version": "3.24.6",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.6.tgz",
+			"integrity": "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-body-length-browser": "^4.2.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-stream": "^4.5.25",
-				"@smithy/util-utf8": "^4.2.2",
-				"@smithy/uuid": "^1.1.2",
+				"@aws-crypto/crc32": "5.2.0",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3072,85 +2521,13 @@
 			}
 		},
 		"node_modules/@smithy/credential-provider-imds": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
-			"integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
+			"version": "4.3.8",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.8.tgz",
+			"integrity": "sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/eventstream-codec": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.14.tgz",
-			"integrity": "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-crypto/crc32": "5.2.0",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-hex-encoding": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/eventstream-serde-browser": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.14.tgz",
-			"integrity": "sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/eventstream-serde-universal": "^4.2.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/eventstream-serde-config-resolver": {
-			"version": "4.3.14",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.14.tgz",
-			"integrity": "sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/eventstream-serde-node": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.14.tgz",
-			"integrity": "sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/eventstream-serde-universal": "^4.2.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/eventstream-serde-universal": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.14.tgz",
-			"integrity": "sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/eventstream-codec": "^4.2.14",
-				"@smithy/types": "^4.14.1",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3158,72 +2535,13 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "5.3.17",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
-			"integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
+			"version": "5.4.6",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.6.tgz",
+			"integrity": "sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/querystring-builder": "^4.2.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-base64": "^4.3.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/hash-blob-browser": {
-			"version": "4.2.15",
-			"resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.15.tgz",
-			"integrity": "sha512-0PJ4Al3fg2nM4qKrAIxyNcApgqHAXcBkN8FeizOz69z0rb26uZ6lMESYtxegaTlXB5Hj84JfwMPavMrwDMjucA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/chunked-blob-reader": "^5.2.2",
-				"@smithy/chunked-blob-reader-native": "^4.2.3",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/hash-node": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
-			"integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-buffer-from": "^4.2.2",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/hash-stream-node": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.14.tgz",
-			"integrity": "sha512-tw4GANWkZPb6+BdD4Fgucqzey2+r73Z/GRo9zklsCdwrnxxumUV83ZIaBDdudV4Ylazw3EPTiJZhpX42105ruQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/invalid-dependency": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
-			"integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3231,122 +2549,24 @@
 			}
 		},
 		"node_modules/@smithy/is-array-buffer": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
-			"integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/md5-js": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.14.tgz",
-			"integrity": "sha512-V2v0vx+h0iUSNG1Alt+GNBMSLGCrl9iVsdd+Ap67HPM9PN479x12V8LkuMoKImNZxn3MXeuyUjls+/7ZACZghA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-content-length": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
-			"integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@smithy/middleware-endpoint": {
-			"version": "4.4.32",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
-			"integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
+			"version": "4.5.6",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.5.6.tgz",
+			"integrity": "sha512-zdG5bJZOiM2PRgL2lwcgui6uwZ+s5y6Qsk/rk05Q69sZJT6oi1x+v8Kn++V/q9VY94EgOtEe5kivpu+eGau0wQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.23.17",
-				"@smithy/middleware-serde": "^4.2.20",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
-				"@smithy/util-middleware": "^4.2.14",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-retry": {
-			"version": "4.5.5",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.5.tgz",
-			"integrity": "sha512-wnYOpB5vATFKWrY2Z9Alb0KhjZI6AbzU6Fbz3Hq2GnURdRYWB4q+qWivQtSTwXcmWUA3MZ6krfwL6Cq5MAbxsA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.23.17",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/service-error-classification": "^4.3.0",
-				"@smithy/smithy-client": "^4.12.13",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-retry": "^4.3.4",
-				"@smithy/uuid": "^1.1.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-serde": {
-			"version": "4.2.20",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
-			"integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.23.17",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-stack": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
-			"integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/node-config-provider": {
-			"version": "4.3.14",
-			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
-			"integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
+				"@smithy/core": "^3.24.6",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3354,27 +2574,13 @@
 			}
 		},
 		"node_modules/@smithy/node-http-handler": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
-			"integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
+			"version": "4.7.7",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.7.tgz",
+			"integrity": "sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/querystring-builder": "^4.2.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/property-provider": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
-			"integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3382,64 +2588,12 @@
 			}
 		},
 		"node_modules/@smithy/protocol-http": {
-			"version": "5.3.14",
-			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
-			"integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
+			"version": "5.4.6",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.4.6.tgz",
+			"integrity": "sha512-H6S7NyaaL+7qO8kIL7VQ7KyrGnKXdllGzJqvtp3hvDen25UOydKV51qGDVK0UciW125jV3CoLJQy/ihc0OEC6A==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/querystring-builder": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
-			"integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-uri-escape": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/querystring-parser": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
-			"integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/service-error-classification": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.0.tgz",
-			"integrity": "sha512-9jKsBYQRPR0xBLgc2415RsA5PIcP2sis4oBdN9s0D13cg1B1284mNTjx9Yc+BEERXzuPm5ObktI96OxsKh8E9A==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/shared-ini-file-loader": {
-			"version": "4.4.9",
-			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
-			"integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
+				"@smithy/core": "^3.24.6",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3447,18 +2601,13 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4": {
-			"version": "5.3.14",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
-			"integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
+			"version": "5.4.6",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.6.tgz",
+			"integrity": "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/is-array-buffer": "^4.2.2",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-hex-encoding": "^4.2.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-uri-escape": "^4.2.2",
-				"@smithy/util-utf8": "^4.2.2",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3466,17 +2615,13 @@
 			}
 		},
 		"node_modules/@smithy/smithy-client": {
-			"version": "4.12.13",
-			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
-			"integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
+			"version": "4.13.6",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.13.6.tgz",
+			"integrity": "sha512-tAf35/JW/DvMlACcazcoIOKOV0JBqyOvxjPTEME9W+m9wLcE0G1rwADc7Ntu38rY5C9OH8jZjpo4tbtjmIjEBQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.23.17",
-				"@smithy/middleware-endpoint": "^4.4.32",
-				"@smithy/middleware-stack": "^4.2.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-stream": "^4.5.25",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3484,61 +2629,9 @@
 			}
 		},
 		"node_modules/@smithy/types": {
-			"version": "4.14.1",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
-			"integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/url-parser": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
-			"integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/querystring-parser": "^4.2.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-base64": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
-			"integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/util-buffer-from": "^4.2.2",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-body-length-browser": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
-			"integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-body-length-node": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
-			"integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+			"version": "4.14.3",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+			"integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -3548,183 +2641,29 @@
 			}
 		},
 		"node_modules/@smithy/util-buffer-from": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
-			"integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/is-array-buffer": "^4.2.2",
+				"@smithy/is-array-buffer": "^2.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-config-provider": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
-			"integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-defaults-mode-browser": {
-			"version": "4.3.49",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
-			"integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/smithy-client": "^4.12.13",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-defaults-mode-node": {
-			"version": "4.2.54",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
-			"integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/config-resolver": "^4.4.17",
-				"@smithy/credential-provider-imds": "^4.2.14",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/smithy-client": "^4.12.13",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-endpoints": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
-			"integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-hex-encoding": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
-			"integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-middleware": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
-			"integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-retry": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.4.tgz",
-			"integrity": "sha512-FY1UQQ1VFmMwiYp1GVS4MeaGD5O0blLNYK0xCRHU+mJgeoH/hSY8Ld8sJWKQ6uznkh14HveRGQJncgPyNl9J+A==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/service-error-classification": "^4.3.0",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-stream": {
-			"version": "4.5.25",
-			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
-			"integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/fetch-http-handler": "^5.3.17",
-				"@smithy/node-http-handler": "^4.6.1",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-buffer-from": "^4.2.2",
-				"@smithy/util-hex-encoding": "^4.2.2",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-uri-escape": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
-			"integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@smithy/util-utf8": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-			"integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-buffer-from": "^2.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-waiter": {
-			"version": "4.2.16",
-			"resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.16.tgz",
-			"integrity": "sha512-GtclrKoZ3Lt7jPQ7aTIYKfjY92OgceScftVnkTsG8e1KV8rkvZgN+ny6YSRhd9hxB8rZtwVbmln7NTvE5O3GmQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/uuid": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
-			"integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@swc/helpers": {
@@ -4030,12 +2969,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.6.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+			"version": "22.19.19",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+			"integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
-				"undici-types": "~7.19.0"
+				"undici-types": "~6.21.0"
 			}
 		},
 		"node_modules/@types/readable-stream": {
@@ -4093,6 +3033,7 @@
 			"integrity": "sha512-JaehZvf6m0yqYp34+RVnihBAChkqeH+tqqhS0GuX1qgPpwLvmTPheKEs6OeCK6hVJgXZHJ2vbjnC9j119auStQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.33.0",
 				"@typescript-eslint/types": "8.33.0",
@@ -4596,6 +3537,7 @@
 			"integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -5269,32 +4211,6 @@
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
 			"license": "MIT"
-		},
-		"node_modules/bufferutil": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
-			"integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"node-gyp-build": "^4.3.0"
-			},
-			"engines": {
-				"node": ">=6.14.2"
-			}
-		},
-		"node_modules/bufferutil/node_modules/node-gyp-build": {
-			"version": "4.8.4",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-			"integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-			"license": "MIT",
-			"optional": true,
-			"bin": {
-				"node-gyp-build": "bin.js",
-				"node-gyp-build-optional": "optional.js",
-				"node-gyp-build-test": "build-test.js"
-			}
 		},
 		"node_modules/bytestreamjs": {
 			"version": "2.0.1",
@@ -6212,6 +5128,7 @@
 			"integrity": "sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -6402,6 +5319,7 @@
 			"integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@rtsao/scc": "^1.1.0",
 				"array-includes": "^3.1.8",
@@ -6835,9 +5753,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/fast-xml-builder": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-			"integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+			"integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
 			"funding": [
 				{
 					"type": "github",
@@ -6846,13 +5764,14 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"path-expression-matcher": "^1.1.3"
+				"path-expression-matcher": "^1.5.0",
+				"xml-naming": "^0.1.0"
 			}
 		},
 		"node_modules/fast-xml-parser": {
-			"version": "5.5.8",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-			"integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+			"version": "5.7.3",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+			"integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
 			"funding": [
 				{
 					"type": "github",
@@ -6861,9 +5780,10 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"fast-xml-builder": "^1.1.4",
-				"path-expression-matcher": "^1.2.0",
-				"strnum": "^2.2.0"
+				"@nodable/entities": "^2.1.0",
+				"fast-xml-builder": "^1.1.7",
+				"path-expression-matcher": "^1.5.0",
+				"strnum": "^2.2.3"
 			},
 			"bin": {
 				"fxparser": "src/cli/cli.js"
@@ -7132,9 +6052,9 @@
 			}
 		},
 		"node_modules/fs-extra": {
-			"version": "11.3.4",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-			"integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+			"version": "11.3.5",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+			"integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
 			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.0",
@@ -7421,6 +6341,7 @@
 			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
 			"integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
 			}
@@ -7479,21 +6400,21 @@
 			}
 		},
 		"node_modules/harper": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/harper/-/harper-5.0.3.tgz",
-			"integrity": "sha512-X3YPsyBVKKAYtrDG8xL6LWTmBj5tMvWx25jam2DQHI0U/a3pHoNWgzCqde33t0/6qxYoUrm4t8teEx+dlSqW2Q==",
+			"version": "5.0.28",
+			"resolved": "https://registry.npmjs.org/harper/-/harper-5.0.28.tgz",
+			"integrity": "sha512-uyY+YlVdlWc8iG+HbpkRV/YaGykabDTiCLD/bN1PilvM0+xZgZiCd3jA+dMhJK5I6qJS1veR/R7OmamrTONCRA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/client-s3": "^3.1012.0",
-				"@aws-sdk/lib-storage": "3.1024.0",
+				"@aws-sdk/lib-storage": "3.1045.0",
 				"@datadog/pprof": "^5.11.1",
 				"@endo/static-module-record": "^1.1.2",
 				"@fastify/autoload": "^6.3.1",
 				"@fastify/compress": "^8.3.1",
 				"@fastify/cors": "^11.2.0",
-				"@fastify/static": "^9.0.0",
+				"@fastify/static": "^9.1.3",
 				"@harperfast/extended-iterable": "^1.0.1",
-				"@harperfast/rocksdb-js": "^1.0.1",
+				"@harperfast/rocksdb-js": "^1.4.2",
 				"@turf/area": "6.5.0",
 				"@turf/boolean-contains": "6.5.0",
 				"@turf/boolean-disjoint": "6.5.0",
@@ -7517,7 +6438,7 @@
 				"fast-glob": "3.3.3",
 				"fastify": "^5.8.2",
 				"fastify-plugin": "^5.1.0",
-				"fs-extra": "11.3.4",
+				"fs-extra": "11.3.5",
 				"graphql": "^16.10.0",
 				"graphql-http": "^1.22.4",
 				"gunzip-maybe": "1.4.2",
@@ -7528,14 +6449,14 @@
 				"json-bigint-fixes": "1.1.0",
 				"jsonata": "1.8.7",
 				"jsonwebtoken": "9.0.3",
-				"lmdb": "3.5.4",
+				"lmdb": "3.5.5",
 				"lodash": "^4.17.23",
 				"mathjs": "11.12.0",
 				"micromatch": "^4.0.8",
 				"minimist": "1.2.8",
 				"moment": "2.30.1",
 				"mqtt-packet": "~9.0.1",
-				"msgpackr": "1.11.9",
+				"msgpackr": "1.11.13",
 				"needle": "3.5.0",
 				"node-forge": "^1.3.1",
 				"node-stream-zip": "1.15.0",
@@ -7552,7 +6473,7 @@
 				"prompt": "1.3.0",
 				"properties-reader": "2.3.0",
 				"recursive-iterator": "3.3.0",
-				"semver": "7.7.4",
+				"semver": "7.8.0",
 				"send": "^1.2.0",
 				"ses": "^1.15.0",
 				"stream-chain": "2.2.5",
@@ -7560,10 +6481,10 @@
 				"systeminformation": "^5.31.4",
 				"tar-fs": "^3.1.2",
 				"ulidx": "0.5.0",
-				"uuid": "11.1.0",
+				"uuid": "11.1.1",
 				"validate.js": "0.13.1",
 				"ws": "8.20.0",
-				"yaml": "2.8.3"
+				"yaml": "2.9.0"
 			},
 			"bin": {
 				"harper": "dist/bin/harper.js"
@@ -8720,9 +7641,9 @@
 			"license": "MIT"
 		},
 		"node_modules/lmdb": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/lmdb/-/lmdb-3.5.4.tgz",
-			"integrity": "sha512-9FKQA6G1MMtqNxfxvSBNXD/axeG2QRjYbNh0/ykRL5xYcRbCm2vXq7B9bhc7nSuKdHzr8/BHIwfPuYYH1UsXXw==",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/lmdb/-/lmdb-3.5.5.tgz",
+			"integrity": "sha512-e2q1RtHdJoDaQQNMJ55wJnD5BqpvzoJIEL3NBxfZXNBjYxY0QjCh3RSL/sqmi+y9l97cERdO4WwGFfYYVft1fA==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8737,13 +7658,13 @@
 				"download-lmdb-prebuilds": "bin/download-prebuilds.js"
 			},
 			"optionalDependencies": {
-				"@lmdb/lmdb-darwin-arm64": "3.5.4",
-				"@lmdb/lmdb-darwin-x64": "3.5.4",
-				"@lmdb/lmdb-linux-arm": "3.5.4",
-				"@lmdb/lmdb-linux-arm64": "3.5.4",
-				"@lmdb/lmdb-linux-x64": "3.5.4",
-				"@lmdb/lmdb-win32-arm64": "3.5.4",
-				"@lmdb/lmdb-win32-x64": "3.5.4"
+				"@lmdb/lmdb-darwin-arm64": "3.5.5",
+				"@lmdb/lmdb-darwin-x64": "3.5.5",
+				"@lmdb/lmdb-linux-arm": "3.5.5",
+				"@lmdb/lmdb-linux-arm64": "3.5.5",
+				"@lmdb/lmdb-linux-x64": "3.5.5",
+				"@lmdb/lmdb-win32-arm64": "3.5.5",
+				"@lmdb/lmdb-win32-x64": "3.5.5"
 			}
 		},
 		"node_modules/lmdb/node_modules/node-addon-api": {
@@ -9079,18 +8000,18 @@
 			"license": "MIT"
 		},
 		"node_modules/msgpackr": {
-			"version": "1.11.9",
-			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.9.tgz",
-			"integrity": "sha512-FkoAAyyA6HM8wL882EcEyFZ9s7hVADSwG9xrVx3dxxNQAtgADTrJoEWivID82Iv1zWDsv/OtbrrcZAzGzOMdNw==",
+			"version": "1.11.13",
+			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.13.tgz",
+			"integrity": "sha512-pWaxg0k1iiNdkAayUQ7Zlz/vYNfVefUttmHxqFcQjjtyqFa3w4x5rginOEzy/GvbWhBDD9K65/ZXyq8qz8utaQ==",
 			"license": "MIT",
 			"optionalDependencies": {
 				"msgpackr-extract": "^3.0.2"
 			}
 		},
 		"node_modules/msgpackr-extract": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
-			"integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+			"integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
@@ -9101,12 +8022,12 @@
 				"download-msgpackr-prebuilds": "bin/download-prebuilds.js"
 			},
 			"optionalDependencies": {
-				"@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
-				"@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
-				"@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
-				"@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
-				"@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
-				"@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+				"@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+				"@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+				"@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+				"@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+				"@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+				"@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
 			}
 		},
 		"node_modules/msgpackr-extract/node_modules/node-gyp-build-optional-packages": {
@@ -9211,6 +8132,7 @@
 			"resolved": "https://registry.npmjs.org/next/-/next-15.5.15.tgz",
 			"integrity": "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@next/env": "15.5.15",
 				"@swc/helpers": "0.5.15",
@@ -10383,6 +9305,7 @@
 			"version": "18.2.0",
 			"resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
 			"integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -10394,6 +9317,7 @@
 			"version": "18.2.0",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
 			"integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.0"
@@ -10852,9 +9776,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+			"integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -11437,9 +10361,9 @@
 			}
 		},
 		"node_modules/strnum": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-			"integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+			"integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
 			"funding": [
 				{
 					"type": "github",
@@ -11699,6 +10623,7 @@
 			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -11930,9 +10855,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "7.19.2",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-			"integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
 			"license": "MIT"
 		},
 		"node_modules/universalify": {
@@ -11987,32 +10912,6 @@
 				"punycode": "^2.1.0"
 			}
 		},
-		"node_modules/utf-8-validate": {
-			"version": "5.0.10",
-			"resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-			"integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"node-gyp-build": "^4.3.0"
-			},
-			"engines": {
-				"node": ">=6.14.2"
-			}
-		},
-		"node_modules/utf-8-validate/node_modules/node-gyp-build": {
-			"version": "4.8.4",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-			"integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-			"license": "MIT",
-			"optional": true,
-			"bin": {
-				"node-gyp-build": "bin.js",
-				"node-gyp-build-optional": "optional.js",
-				"node-gyp-build-test": "build-test.js"
-			}
-		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -12029,9 +10928,9 @@
 			}
 		},
 		"node_modules/uuid": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+			"integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
@@ -12259,6 +11158,21 @@
 				}
 			}
 		},
+		"node_modules/xml-naming": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+			"integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
 		"node_modules/xtend": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -12278,9 +11192,9 @@
 			}
 		},
 		"node_modules/yaml": {
-			"version": "2.8.3",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-			"integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
 			"license": "ISC",
 			"bin": {
 				"yaml": "bin.mjs"
@@ -12330,6 +11244,58 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/bufferutil": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+			"integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"node-gyp-build": "^4.3.0"
+			},
+			"engines": {
+				"node": ">=6.14.2"
+			}
+		},
+		"node_modules/utf-8-validate": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+			"integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"node-gyp-build": "^4.3.0"
+			},
+			"engines": {
+				"node": ">=6.14.2"
+			}
+		},
+		"node_modules/bufferutil/node_modules/node-gyp-build": {
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+			"integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+			"license": "MIT",
+			"optional": true,
+			"bin": {
+				"node-gyp-build": "bin.js",
+				"node-gyp-build-optional": "optional.js",
+				"node-gyp-build-test": "build-test.js"
+			}
+		},
+		"node_modules/utf-8-validate/node_modules/node-gyp-build": {
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+			"integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+			"license": "MIT",
+			"optional": true,
+			"bin": {
+				"node-gyp-build": "bin.js",
+				"node-gyp-build-optional": "optional.js",
+				"node-gyp-build-test": "build-test.js"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
 	"private": true,
 	"license": "Apache-2.0",
 	"scripts": {
+		"dev": "harper-nextjs dev",
+		"build": "next build",
+		"start": "next start",
+		"lint": "next lint",
+		"format": "prettier --write .",
 		"test:integration": "harper-integration-test-run --isolation=none \"integrationTests/**/*.test.ts\""
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"scripts": {},
 	"dependencies": {
 		"@harperfast/nextjs": "2.0.0",
-		"harper": "5.0.3",
+		"harper": "^5.0.10",
 		"next": "15.5.15",
 		"react": "18",
 		"react-dom": "18"

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
 	"version": "0.1.0",
 	"private": true,
 	"license": "Apache-2.0",
-	"scripts": {},
+	"scripts": {
+		"test:integration": "harper-integration-test-run --isolation=none \"integrationTests/**/*.test.ts\""
+	},
 	"dependencies": {
-		"@harperfast/nextjs": "2.0.0",
+		"@harperfast/nextjs": "2.2.1",
 		"harper": "^5.0.10",
 		"next": "15.5.15",
 		"react": "18",
@@ -13,10 +15,13 @@
 	},
 	"devDependencies": {
 		"@harperdb/code-guidelines": "0.0.2",
+		"@harperfast/integration-testing": "^0.4.0",
+		"@types/node": "^22.0.0",
 		"eslint": "9.27.0",
 		"eslint-config-next": "15.3.3",
 		"eslint-config-prettier": "10.1.5",
-		"prettier": "3.5.3"
+		"prettier": "3.5.3",
+		"typescript": "^5.6.0"
 	},
 	"prettier": "@harperdb/code-guidelines/prettier"
 }


### PR DESCRIPTION
## Harper v5 upgrade — completion (Path B)

This repo was already on `harper@^5` (the dependency swap was done in the prior commit) but was missing the integration-testing setup. This PR completes the v5 upgrade: adds integration tests, the standard CI workflow, finishes the v4→v5 CLI/branding cleanup, and resyncs a stale lockfile.

### Changes
- **Integration testing:** added `@harperfast/integration-testing@^0.4.0`, `typescript`, `@types/node`, a `test:integration` script, and `integrationTests/app.test.ts`. The tests boot the full component as a fixture under v5 and verify:
  1. the component boots and the `Dog` table is defined (Operations API `describe_all`),
  2. `insert` / `search_by_id` / `delete` on the `Dog` table,
  3. the Next.js `/` and `/dogs` pages render (HTTP 200 HTML).
  - **Architecture note:** the `@harperfast/nextjs` plugin owns the public HTTP port and routes everything to the Next.js app, so the `Dog @table @export` REST endpoint is *not* reachable over HTTP. The Next.js server actions (`app/actions.js`) use that table through Harper's in-process Resource API (`tables.Dog`); the tests drive the same data layer via the Operations API.
- **harperBinPath fix (mandatory):** `harper`'s `exports` map only exposes `"."`, so the harness's auto-resolution of `harper/dist/bin/harper.js` throws `ERR_PACKAGE_PATH_NOT_EXPORTED`. The test resolves the CLI from the exported main entry and passes it explicitly as `harperBinPath`. (Upstream: harper should export its bin path, or the harness should resolve via the package root.)
- **Lockfile resync:** `package.json` already requested `harper@^5.0.10`, but `package-lock.json` still pinned `harper@5.0.3` and carried a stale `../harper` extraneous local-path entry. Resolved harper to **5.0.28**, removed the stale `../harper` block, and preserved harper's optional native deps (`bufferutil`, `utf-8-validate`, `node-gyp-build`) — a macOS `npm install` had dropped them, which broke `npm ci` on Linux. `npm ci` verified clean on macOS and via `--os=linux` dry-run (glibc + musl).
- **Plugin bump:** `@harperfast/nextjs` `2.0.0` → `2.2.1` (latest).
- **CI:** added `.github/workflows/integration-tests.yml` (Node matrix 22/24/26, actions pinned to commit hashes).
- **v4→v5 CLI + branding cleanup** in `.github/workflows/build-and-deploy.yml`: `harperdb` CLI → `harper`, `@harperdb/nextjs` → `@harperfast/nextjs`, `HarperDB` log/artifact names → `Harper`.
- **README:** `harperdb deploy` → `harper deploy`. Live `docs.harperdb.io` URLs left intact.

### Migration items
This is a Next.js component that talks to Harper through the `@harperfast/nextjs` plugin and the Resource API (`tables.Dog`), via `import('harper')`. No v4 footprints found in source (no `from 'harperdb'`, no `blob.save(`, no `wasLoadedFromSource(`, no `harperdb-config.yaml`). **N/A** migration items: `harperdb`→`harper` import swap (already uses `import('harper')`), `Table.get()` return-shape / frozen records (server actions only read fields off the result), transaction/context changes, child-process spawning, blob storage, and module-loading/install-script config.

### Tests
Local run (`npm run test:integration`, `--isolation=none`): **4/4 pass** — the single-instance isolation mode binds to 127.0.0.1, so the usual macOS multi-loopback limitation does not block it. CI (Node 22/24/26 on `ubuntu-latest`) is the authoritative gate; see the Integration Tests check on this PR.

### Notes / flags
- The integration-test fixture boots the **full component**, which loads the `@harperfast/nextjs` plugin on startup. The plugin is not modified by this PR and boots cleanly under harper 5.0.28 + plugin 2.2.1 in local testing.
- `@harperdb/code-guidelines` (devDependency + prettier config) is intentionally left on the `@harperdb` npm scope — no `@harperfast` variant is published. No manual npm-scope action needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)